### PR TITLE
PIPRES-352: Billie payment method setup

### DIFF
--- a/src/Builder/FormBuilder.php
+++ b/src/Builder/FormBuilder.php
@@ -406,8 +406,6 @@ class FormBuilder
             'customLogoUrl' => $this->creditCardLogoProvider->getLogoPathUri() . "?{$dateStamp}",
             'customLogoExist' => $this->creditCardLogoProvider->logoExists(),
             'voucherCategory' => $this->configurationAdapter->get(Config::MOLLIE_VOUCHER_CATEGORY),
-            'klarnaPayments' => Config::KLARNA_PAYMENTS,
-            'klarnaStatuses' => [Config::MOLLIE_STATUS_KLARNA_AUTHORIZED, Config::MOLLIE_STATUS_KLARNA_SHIPPED],
             'applePayDirectProduct' => (int) $this->configurationAdapter->get(Config::MOLLIE_APPLE_PAY_DIRECT_PRODUCT),
             'applePayDirectCart' => (int) $this->configurationAdapter->get(Config::MOLLIE_APPLE_PAY_DIRECT_CART),
             'applePayDirectStyle' => (int) $this->configurationAdapter->get(Config::MOLLIE_APPLE_PAY_DIRECT_STYLE),
@@ -481,22 +479,22 @@ class FormBuilder
 
         $input[] = [
             'type' => 'select',
-            'label' => $this->module->l('Select when to create the Klarna invoice', self::FILE_NAME),
+            'label' => $this->module->l('Select when to create the Order invoice', self::FILE_NAME),
             'desc' => $this->module->display($this->module->getPathUri(), 'views/templates/admin/invoice_description.tpl'),
             'tab' => $advancedSettings,
-            'name' => Config::MOLLIE_KLARNA_INVOICE_ON,
+            'name' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS,
             'options' => [
                 'query' => [
                     [
-                        'id' => Config::MOLLIE_STATUS_DEFAULT,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT,
                         'name' => $this->module->l('Default', self::FILE_NAME),
                     ],
                     [
-                        'id' => Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
                         'name' => $this->module->l('Authorised', self::FILE_NAME),
                     ],
                     [
-                        'id' => Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
                         'name' => $this->module->l('Shipped', self::FILE_NAME),
                     ],
                 ],

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -144,11 +144,11 @@ class Config
     const MOLLIE_STATUS_INITIATED = 'MOLLIE_STATUS_INITIATED';
     const MOLLIE_STATUS_PARTIALLY_SHIPPED = 'MOLLIE_PARTIALLY_SHIPPED';
     const MOLLIE_STATUS_ORDER_COMPLETED = 'MOLLIE_STATUS_ORDER_COMPLETED';
-    const MOLLIE_STATUS_DEFAULT = 'MOLLIE_STATUS_DEFAULT';
-    const MOLLIE_STATUS_KLARNA_AUTHORIZED = 'MOLLIE_STATUS_KLARNA_AUTHORIZED';
-    const MOLLIE_STATUS_KLARNA_SHIPPED = 'MOLLIE_STATUS_KLARNA_SHIPPED';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED';
     const MOLLIE_STATUS_CHARGEBACK = 'MOLLIE_STATUS_CHARGEBACK';
-    const MOLLIE_KLARNA_INVOICE_ON = 'MOLLIE_KLARNA_INVOICE_ON';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS = 'MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS';
     const MOLLIE_APPLE_PAY_DIRECT_PRODUCT = 'MOLLIE_APPLE_PAY_DIRECT_PRODUCT';
     const MOLLIE_APPLE_PAY_DIRECT_CART = 'MOLLIE_APPLE_PAY_DIRECT_CART';
 
@@ -262,16 +262,18 @@ class Config
     const RESTORE_CART_BACKTRACE_MEMORIZATION_SERVICE = 'memo';
     const RESTORE_CART_BACKTRACE_RETURN_CONTROLLER = 'return';
 
-    const KLARNA_PAYMENTS = [
+    const AUTHORIZABLE_PAYMENTS = [
         PaymentMethod::KLARNA_PAY_LATER,
         PaymentMethod::KLARNA_SLICE_IT,
         PaymentMethod::KLARNA_PAY_NOW,
+        self::MOLLIE_PAYMENT_METHOD_BILLIE,
     ];
 
     const ORDER_API_ONLY_METHODS = [
         PaymentMethod::KLARNA_PAY_LATER,
         PaymentMethod::KLARNA_SLICE_IT,
         PaymentMethod::KLARNA_PAY_NOW,
+        self::MOLLIE_PAYMENT_METHOD_BILLIE,
         self::MOLLIE_VOUCHER_METHOD_ID,
         self::MOLLIE_in3_METHOD_ID,
     ];
@@ -309,6 +311,7 @@ class Config
         'voucher' => 'Voucher',
         'klarnapaynow' => 'Klarna Pay now.',
         'in3' => 'in3',
+        'billie' => 'Billie',
     ];
 
     const MOLLIE_BUTTON_ORDER_TOTAL_REFRESH = 'MOLLIE_BUTTON_ORDER_TOTAL_REFRESH';
@@ -318,14 +321,15 @@ class Config
 
     public static function getStatuses()
     {
-        $isKlarnaDefault = Configuration::get(Config::MOLLIE_KLARNA_INVOICE_ON) === Config::MOLLIE_STATUS_DEFAULT;
+        $isAuthorizablePaymentInvoiceOnStatusDefault =
+            Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS) === Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT;
 
         return [
             self::MOLLIE_AWAITING_PAYMENT => Configuration::get(self::MOLLIE_STATUS_AWAITING),
             PaymentStatus::STATUS_PAID => Configuration::get(self::MOLLIE_STATUS_PAID),
             OrderStatus::STATUS_COMPLETED => Configuration::get(self::MOLLIE_STATUS_COMPLETED),
-            PaymentStatus::STATUS_AUTHORIZED => $isKlarnaDefault ?
-                Configuration::get(self::MOLLIE_STATUS_PAID) : Configuration::get(self::MOLLIE_STATUS_KLARNA_AUTHORIZED),
+            PaymentStatus::STATUS_AUTHORIZED => $isAuthorizablePaymentInvoiceOnStatusDefault ?
+                Configuration::get(self::MOLLIE_STATUS_PAID) : Configuration::get(self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED),
             PaymentStatus::STATUS_CANCELED => Configuration::get(self::MOLLIE_STATUS_CANCELED),
             PaymentStatus::STATUS_EXPIRED => Configuration::get(self::MOLLIE_STATUS_EXPIRED),
             RefundStatus::STATUS_REFUNDED => Configuration::get(self::MOLLIE_STATUS_REFUNDED),
@@ -338,7 +342,7 @@ class Config
             self::STATUS_PAID_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK_PAID'),
             self::STATUS_PENDING_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK_UNPAID'),
             self::STATUS_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK'),
-            self::MOLLIE_STATUS_KLARNA_SHIPPED => Configuration::get(self::MOLLIE_STATUS_KLARNA_SHIPPED),
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED => Configuration::get(self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED),
             self::MOLLIE_CHARGEBACK => Configuration::get(self::MOLLIE_STATUS_CHARGEBACK),
         ];
     }
@@ -360,8 +364,8 @@ class Config
             self::MOLLIE_STATUS_PARTIAL_REFUND,
             self::MOLLIE_STATUS_AWAITING,
             self::MOLLIE_STATUS_ORDER_COMPLETED,
-            self::MOLLIE_STATUS_KLARNA_AUTHORIZED,
-            self::MOLLIE_STATUS_KLARNA_SHIPPED,
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
             self::MOLLIE_STATUS_CHARGEBACK,
         ];
     }

--- a/src/Handler/Certificate/ApplePayDirectCertificateHandler.php
+++ b/src/Handler/Certificate/ApplePayDirectCertificateHandler.php
@@ -13,6 +13,7 @@
 namespace Mollie\Handler\Certificate;
 
 use Mollie;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Handler\Certificate\Exception\ApplePayDirectCertificateCreation;
 use Mollie\Utility\FileUtility;
 
@@ -30,9 +31,9 @@ class ApplePayDirectCertificateHandler implements CertificateHandlerInterface
     private $mollie;
     private $serverRoot;
 
-    public function __construct(Mollie $mollie)
+    public function __construct(ModuleFactory $moduleFactory)
     {
-        $this->mollie = $mollie;
+        $this->mollie = $moduleFactory->getModule();
         $this->serverRoot = $_SERVER['DOCUMENT_ROOT'];
     }
 

--- a/src/Handler/Order/OrderCreationHandler.php
+++ b/src/Handler/Order/OrderCreationHandler.php
@@ -99,9 +99,9 @@ class OrderCreationHandler
      *
      * @throws \Exception
      */
-    public function createOrder($apiPayment, int $cartId, bool $isKlarnaOrder = false): int
+    public function createOrder($apiPayment, int $cartId, bool $isAuthorizablePayment = false): int
     {
-        $orderStatus = $isKlarnaOrder ?
+        $orderStatus = $isAuthorizablePayment ?
             (int) Config::getStatuses()[PaymentStatus::STATUS_AUTHORIZED] :
             (int) Config::getStatuses()[PaymentStatus::STATUS_PAID];
 

--- a/src/Install/OrderStateInstaller.php
+++ b/src/Install/OrderStateInstaller.php
@@ -33,7 +33,7 @@ class OrderStateInstaller implements InstallerInterface
     /**
      * @throws CouldNotInstallModule
      */
-    public function install()
+    public function install(): bool
     {
         $this->installOrderState(
             Config::MOLLIE_STATUS_PARTIAL_REFUND,
@@ -69,9 +69,9 @@ class OrderStateInstaller implements InstallerInterface
         );
 
         $this->installOrderState(
-            Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
             new OrderStateData(
-                'Klarna payment authorized',
+                'Order payment authorized',
                 '#8A2BE2',
                 true,
                 true,
@@ -85,9 +85,9 @@ class OrderStateInstaller implements InstallerInterface
         );
 
         $this->installOrderState(
-            Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
             new OrderStateData(
-                'Klarna payment shipped',
+                'Order payment shipped',
                 '#8A2BE2',
                 true,
                 true,

--- a/src/Presenter/OrderListActionBuilder.php
+++ b/src/Presenter/OrderListActionBuilder.php
@@ -13,6 +13,7 @@
 namespace Mollie\Presenter;
 
 use Mollie;
+use Mollie\Factory\ModuleFactory;
 use Smarty_Data;
 
 class OrderListActionBuilder
@@ -23,9 +24,9 @@ class OrderListActionBuilder
      */
     private $mollie;
 
-    public function __construct(Mollie $mollie)
+    public function __construct(ModuleFactory $moduleFactory)
     {
-        $this->mollie = $mollie;
+        $this->mollie = $moduleFactory->getModule();
     }
 
     public function buildOrderPaymentResendButton(Smarty_Data $smarty, $orderId)

--- a/src/Provider/PaymentOption/BancontactPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/BancontactPaymentOptionProvider.php
@@ -39,6 +39,7 @@ namespace Mollie\Provider\PaymentOption;
 use Mollie;
 use Mollie\Adapter\Context;
 use Mollie\Api\Types\PaymentMethod;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\OrderTotal\OrderTotalProviderInterface;
 use Mollie\Provider\PaymentFeeProviderInterface;
@@ -79,14 +80,14 @@ class BancontactPaymentOptionProvider implements PaymentOptionProviderInterface
     private $orderTotalProvider;
 
     public function __construct(
-        Mollie $module,
+        ModuleFactory $moduleFactory,
         Context $context,
         CreditCardLogoProvider $creditCardLogoProvider,
         PaymentFeeProviderInterface $paymentFeeProvider,
         LanguageService $languageService,
         OrderTotalProviderInterface $orderTotalProvider
     ) {
-        $this->module = $module;
+        $this->module = $moduleFactory->getModule();
         $this->context = $context;
         $this->creditCardLogoProvider = $creditCardLogoProvider;
         $this->paymentFeeProvider = $paymentFeeProvider;

--- a/src/Provider/PaymentOption/BasePaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/BasePaymentOptionProvider.php
@@ -38,6 +38,7 @@ namespace Mollie\Provider\PaymentOption;
 
 use Mollie;
 use Mollie\Adapter\Context;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\OrderTotal\OrderTotalProviderInterface;
 use Mollie\Provider\PaymentFeeProviderInterface;
@@ -78,14 +79,14 @@ class BasePaymentOptionProvider implements PaymentOptionProviderInterface
     private $orderTotalProvider;
 
     public function __construct(
-        Mollie $module,
+        ModuleFactory $moduleFactory,
         Context $context,
         CreditCardLogoProvider $creditCardLogoProvider,
         PaymentFeeProviderInterface $paymentFeeProvider,
         LanguageService $languageService,
         OrderTotalProviderInterface $orderTotalProvider
     ) {
-        $this->module = $module;
+        $this->module = $moduleFactory->getModule();
         $this->context = $context;
         $this->creditCardLogoProvider = $creditCardLogoProvider;
         $this->paymentFeeProvider = $paymentFeeProvider;

--- a/src/Provider/PaymentOption/CreditCardPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/CreditCardPaymentOptionProvider.php
@@ -41,6 +41,7 @@ use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Adapter\Context;
 use Mollie\Config\Config;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\OrderTotal\OrderTotalProviderInterface;
 use Mollie\Provider\PaymentFeeProviderInterface;
@@ -92,7 +93,7 @@ class CreditCardPaymentOptionProvider implements PaymentOptionProviderInterface
     private $configurationAdapter;
 
     public function __construct(
-        Mollie $module,
+        ModuleFactory $moduleFactory,
         Context $context,
         CreditCardLogoProvider $creditCardLogoProvider,
         OrderTotalProviderInterface $orderTotalProvider,
@@ -101,7 +102,7 @@ class CreditCardPaymentOptionProvider implements PaymentOptionProviderInterface
         MolCustomerRepository $customerRepository,
         ConfigurationAdapter $configurationAdapter
     ) {
-        $this->module = $module;
+        $this->module = $moduleFactory->getModule();
         $this->context = $context;
         $this->creditCardLogoProvider = $creditCardLogoProvider;
         $this->orderTotalProvider = $orderTotalProvider;

--- a/src/Provider/PaymentOption/CreditCardSingleClickPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/CreditCardSingleClickPaymentOptionProvider.php
@@ -41,6 +41,7 @@ use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Adapter\Context;
 use Mollie\Config\Config;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\OrderTotal\OrderTotalProviderInterface;
 use Mollie\Provider\PaymentFeeProviderInterface;
@@ -92,7 +93,7 @@ class CreditCardSingleClickPaymentOptionProvider implements PaymentOptionProvide
     private $configurationAdapter;
 
     public function __construct(
-        Mollie $module,
+        ModuleFactory $moduleFactory,
         Context $context,
         CreditCardLogoProvider $creditCardLogoProvider,
         OrderTotalProviderInterface $orderTotalProvider,
@@ -101,7 +102,7 @@ class CreditCardSingleClickPaymentOptionProvider implements PaymentOptionProvide
         MolCustomerRepository $customerRepository,
         ConfigurationAdapter $configurationAdapter
     ) {
-        $this->module = $module;
+        $this->module = $moduleFactory->getModule();
         $this->context = $context;
         $this->creditCardLogoProvider = $creditCardLogoProvider;
         $this->orderTotalProvider = $orderTotalProvider;

--- a/src/Provider/PaymentOption/IdealPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/IdealPaymentOptionProvider.php
@@ -39,6 +39,7 @@ namespace Mollie\Provider\PaymentOption;
 use Mollie;
 use Mollie\Adapter\Context;
 use Mollie\Builder\Content\PaymentOption\IdealDropdownInfoBlock;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\OrderTotal\OrderTotalProviderInterface;
 use Mollie\Provider\PaymentFeeProviderInterface;
@@ -90,7 +91,7 @@ class IdealPaymentOptionProvider implements PaymentOptionProviderInterface
     private $orderTotalProvider;
 
     public function __construct(
-        Mollie $module,
+        ModuleFactory $moduleFactory,
         Context $context,
         CreditCardLogoProvider $creditCardLogoProvider,
         PaymentFeeProviderInterface $paymentFeeProvider,
@@ -99,7 +100,7 @@ class IdealPaymentOptionProvider implements PaymentOptionProviderInterface
         LanguageService $languageService,
         OrderTotalProviderInterface $orderTotalProvider
     ) {
-        $this->module = $module;
+        $this->module = $moduleFactory->getModule();
         $this->context = $context;
         $this->creditCardLogoProvider = $creditCardLogoProvider;
         $this->paymentFeeProvider = $paymentFeeProvider;

--- a/src/Service/ConfigFieldService.php
+++ b/src/Service/ConfigFieldService.php
@@ -12,12 +12,12 @@
 
 namespace Mollie\Service;
 
-use Configuration;
 use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Config\Config;
 use Mollie\Factory\ModuleFactory;
 use Mollie\Repository\CountryRepository;
+use Mollie\Utility\EnvironmentUtility;
 
 class ConfigFieldService
 {
@@ -54,67 +54,71 @@ class ConfigFieldService
     public function getConfigFieldsValues()
     {
         $configFields = [
-            Config::MOLLIE_ENVIRONMENT => Configuration::get(Config::MOLLIE_ENVIRONMENT),
-            Config::MOLLIE_API_KEY => Configuration::get(Config::MOLLIE_API_KEY),
-            Config::MOLLIE_API_KEY_TEST => Configuration::get(Config::MOLLIE_API_KEY_TEST),
-            Config::MOLLIE_PAYMENTSCREEN_LOCALE => Configuration::get(Config::MOLLIE_PAYMENTSCREEN_LOCALE),
-            Config::MOLLIE_SEND_ORDER_CONFIRMATION => Configuration::get(Config::MOLLIE_SEND_ORDER_CONFIRMATION),
+            Config::MOLLIE_ENVIRONMENT => $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT),
+            Config::MOLLIE_API_KEY => $this->configurationAdapter->get(Config::MOLLIE_API_KEY),
+            Config::MOLLIE_API_KEY_TEST => $this->configurationAdapter->get(Config::MOLLIE_API_KEY_TEST),
+            Config::MOLLIE_PAYMENTSCREEN_LOCALE => $this->configurationAdapter->get(Config::MOLLIE_PAYMENTSCREEN_LOCALE),
+            Config::MOLLIE_SEND_ORDER_CONFIRMATION => $this->configurationAdapter->get(Config::MOLLIE_SEND_ORDER_CONFIRMATION),
             Config::MOLLIE_IFRAME[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_IFRAME),
             Config::MOLLIE_SINGLE_CLICK_PAYMENT[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_SINGLE_CLICK_PAYMENT),
 
-            Config::MOLLIE_CSS => Configuration::get(Config::MOLLIE_CSS),
-            Config::MOLLIE_IMAGES => Configuration::get(Config::MOLLIE_IMAGES),
-            Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK => Configuration::get(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK),
+            Config::MOLLIE_CSS => $this->configurationAdapter->get(Config::MOLLIE_CSS),
+            Config::MOLLIE_IMAGES => $this->configurationAdapter->get(Config::MOLLIE_IMAGES),
+            Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK => $this->configurationAdapter->get(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK),
             Config::MOLLIE_ISSUERS[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_ISSUERS),
 
-            Config::MOLLIE_METHOD_COUNTRIES => Configuration::get(Config::MOLLIE_METHOD_COUNTRIES),
-            Config::MOLLIE_METHOD_COUNTRIES_DISPLAY => Configuration::get(Config::MOLLIE_METHOD_COUNTRIES_DISPLAY),
+            Config::MOLLIE_METHOD_COUNTRIES => $this->configurationAdapter->get(Config::MOLLIE_METHOD_COUNTRIES),
+            Config::MOLLIE_METHOD_COUNTRIES_DISPLAY => $this->configurationAdapter->get(Config::MOLLIE_METHOD_COUNTRIES_DISPLAY),
 
-            Config::MOLLIE_STATUS_OPEN => Configuration::get(Config::MOLLIE_STATUS_OPEN),
-            Config::MOLLIE_STATUS_AWAITING => Configuration::get(Config::MOLLIE_STATUS_AWAITING),
-            Config::MOLLIE_STATUS_PAID => Configuration::get(Config::MOLLIE_STATUS_PAID),
-            Config::MOLLIE_STATUS_COMPLETED => Configuration::get(Config::MOLLIE_STATUS_COMPLETED),
-            Config::MOLLIE_STATUS_CANCELED => Configuration::get(Config::MOLLIE_STATUS_CANCELED),
-            Config::MOLLIE_STATUS_EXPIRED => Configuration::get(Config::MOLLIE_STATUS_EXPIRED),
-            Config::MOLLIE_STATUS_PARTIAL_REFUND => Configuration::get(Config::MOLLIE_STATUS_PARTIAL_REFUND),
-            Config::MOLLIE_STATUS_REFUNDED => Configuration::get(Config::MOLLIE_STATUS_REFUNDED),
-            Config::MOLLIE_STATUS_CHARGEBACK => Configuration::get(Config::MOLLIE_STATUS_CHARGEBACK),
-            Config::MOLLIE_MAIL_WHEN_OPEN => Configuration::get(Config::MOLLIE_MAIL_WHEN_OPEN),
-            Config::MOLLIE_MAIL_WHEN_AWAITING => Configuration::get(Config::MOLLIE_MAIL_WHEN_AWAITING),
-            Config::MOLLIE_MAIL_WHEN_PAID => Configuration::get(Config::MOLLIE_MAIL_WHEN_PAID),
-            Config::MOLLIE_MAIL_WHEN_COMPLETED => Configuration::get(Config::MOLLIE_MAIL_WHEN_COMPLETED),
-            Config::MOLLIE_MAIL_WHEN_CANCELED => Configuration::get(Config::MOLLIE_MAIL_WHEN_CANCELED),
-            Config::MOLLIE_MAIL_WHEN_EXPIRED => Configuration::get(Config::MOLLIE_MAIL_WHEN_EXPIRED),
-            Config::MOLLIE_MAIL_WHEN_REFUNDED => Configuration::get(Config::MOLLIE_MAIL_WHEN_REFUNDED),
-            Config::MOLLIE_MAIL_WHEN_CHARGEBACK => Configuration::get(Config::MOLLIE_MAIL_WHEN_CHARGEBACK),
-            Config::MOLLIE_ACCOUNT_SWITCH => Configuration::get(Config::MOLLIE_ACCOUNT_SWITCH),
+            Config::MOLLIE_STATUS_OPEN => $this->configurationAdapter->get(Config::MOLLIE_STATUS_OPEN),
+            Config::MOLLIE_STATUS_AWAITING => $this->configurationAdapter->get(Config::MOLLIE_STATUS_AWAITING),
+            Config::MOLLIE_STATUS_PAID => $this->configurationAdapter->get(Config::MOLLIE_STATUS_PAID),
+            Config::MOLLIE_STATUS_COMPLETED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_COMPLETED),
+            Config::MOLLIE_STATUS_CANCELED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_CANCELED),
+            Config::MOLLIE_STATUS_EXPIRED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_EXPIRED),
+            Config::MOLLIE_STATUS_PARTIAL_REFUND => $this->configurationAdapter->get(Config::MOLLIE_STATUS_PARTIAL_REFUND),
+            Config::MOLLIE_STATUS_REFUNDED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_REFUNDED),
+            Config::MOLLIE_STATUS_CHARGEBACK => $this->configurationAdapter->get(Config::MOLLIE_STATUS_CHARGEBACK),
+            Config::MOLLIE_MAIL_WHEN_OPEN => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_OPEN),
+            Config::MOLLIE_MAIL_WHEN_AWAITING => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_AWAITING),
+            Config::MOLLIE_MAIL_WHEN_PAID => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_PAID),
+            Config::MOLLIE_MAIL_WHEN_COMPLETED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_COMPLETED),
+            Config::MOLLIE_MAIL_WHEN_CANCELED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_CANCELED),
+            Config::MOLLIE_MAIL_WHEN_EXPIRED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_EXPIRED),
+            Config::MOLLIE_MAIL_WHEN_REFUNDED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_REFUNDED),
+            Config::MOLLIE_MAIL_WHEN_CHARGEBACK => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_CHARGEBACK),
+            Config::MOLLIE_ACCOUNT_SWITCH => $this->configurationAdapter->get(Config::MOLLIE_ACCOUNT_SWITCH),
 
-            Config::MOLLIE_DISPLAY_ERRORS => Configuration::get(Config::MOLLIE_DISPLAY_ERRORS),
-            Config::MOLLIE_DEBUG_LOG => Configuration::get(Config::MOLLIE_DEBUG_LOG),
-            Config::MOLLIE_API => Configuration::get(Config::MOLLIE_API),
+            Config::MOLLIE_DISPLAY_ERRORS => $this->configurationAdapter->get(Config::MOLLIE_DISPLAY_ERRORS),
+            Config::MOLLIE_DEBUG_LOG => $this->configurationAdapter->get(Config::MOLLIE_DEBUG_LOG),
+            Config::MOLLIE_API => $this->configurationAdapter->get(Config::MOLLIE_API),
 
-            Config::MOLLIE_AUTO_SHIP_MAIN => Configuration::get(Config::MOLLIE_AUTO_SHIP_MAIN),
+            Config::MOLLIE_AUTO_SHIP_MAIN => $this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_MAIN),
 
-            Config::MOLLIE_STATUS_SHIPPING => Configuration::get(Config::MOLLIE_STATUS_SHIPPING),
-            Config::MOLLIE_MAIL_WHEN_SHIPPING => Configuration::get(Config::MOLLIE_MAIL_WHEN_SHIPPING),
-            Config::MOLLIE_KLARNA_INVOICE_ON => Configuration::get(Config::MOLLIE_KLARNA_INVOICE_ON),
+            Config::MOLLIE_STATUS_SHIPPING => $this->configurationAdapter->get(Config::MOLLIE_STATUS_SHIPPING),
+            Config::MOLLIE_MAIL_WHEN_SHIPPING => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_SHIPPING),
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS => $this->configurationAdapter->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS),
         ];
 
-        if (Mollie\Utility\EnvironmentUtility::getApiKey() && $this->module->getApiClient() !== null) {
+        if (EnvironmentUtility::getApiKey() && $this->module->getApiClient() !== null) {
             foreach ($this->apiService->getMethodsForConfig($this->module->getApiClient()) as $method) {
                 $countryIds = $this->countryRepository->getMethodCountryIds($method['id']);
+
                 if ($countryIds) {
-                    $configFields = array_merge($configFields, [Config::MOLLIE_COUNTRIES . $method['id'] . '[]' => $countryIds]);
+                    $configFields[Config::MOLLIE_COUNTRIES . $method['id'] . '[]'] = $countryIds;
+
                     continue;
                 }
-                $configFields = array_merge($configFields, [Config::MOLLIE_COUNTRIES . $method['id'] . '[]' => []]);
+
+                $configFields[Config::MOLLIE_COUNTRIES . $method['id'] . '[]'] = [];
             }
         }
 
         $checkStatuses = [];
-        if (Configuration::get(Config::MOLLIE_AUTO_SHIP_STATUSES)) {
-            $checkConfs = @json_decode(Configuration::get(Config::MOLLIE_AUTO_SHIP_STATUSES), true);
+        if ($this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_STATUSES)) {
+            $checkConfs = @json_decode($this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_STATUSES), true);
         }
+
         if (!isset($checkConfs) || !is_array($checkConfs)) {
             $checkConfs = [];
         }
@@ -123,8 +127,6 @@ class ConfigFieldService
             $checkStatuses[Config::MOLLIE_AUTO_SHIP_STATUSES . '_' . (int) $conf] = true;
         }
 
-        $configFields = array_merge($configFields, $checkStatuses);
-
-        return $configFields;
+        return array_merge($configFields, $checkStatuses);
     }
 }

--- a/src/Service/CustomerService.php
+++ b/src/Service/CustomerService.php
@@ -16,6 +16,7 @@ use MolCustomer;
 use Mollie;
 use Mollie\Config\Config;
 use Mollie\Exception\MollieException;
+use Mollie\Factory\ModuleFactory;
 use Mollie\Repository\MolCustomerRepository;
 use Mollie\Utility\CustomerUtility;
 
@@ -31,9 +32,9 @@ class CustomerService
      */
     private $customerRepository;
 
-    public function __construct(Mollie $mollie, MolCustomerRepository $customerRepository)
+    public function __construct(ModuleFactory $moduleFactory, MolCustomerRepository $customerRepository)
     {
-        $this->mollie = $mollie;
+        $this->mollie = $moduleFactory->getModule();
         $this->customerRepository = $customerRepository;
     }
 

--- a/src/Service/OrderStatusService.php
+++ b/src/Service/OrderStatusService.php
@@ -157,6 +157,6 @@ class OrderStatusService
     {
         return ((int) $statusId === (int) Configuration::get(Config::MOLLIE_STATUS_PAID)) ||
             ((int) $statusId === (int) Configuration::get(Config::STATUS_PS_OS_OUTOFSTOCK_PAID)) ||
-            ((int) $statusId === (int) Configuration::get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED));
+            ((int) $statusId === (int) Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED));
     }
 }

--- a/src/Service/SettingsSaveService.php
+++ b/src/Service/SettingsSaveService.php
@@ -385,11 +385,11 @@ class SettingsSaveService
 
     private function handleAuthorizablePaymentInvoiceStatus()
     {
-        $klarnaInvoiceStatus = (string) Tools::getValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS);
+        $authorizablePaymentInvoiceOnStatus = (string) Tools::getValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS);
 
-        $this->configurationAdapter->updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS, $klarnaInvoiceStatus);
+        $this->configurationAdapter->updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS, $authorizablePaymentInvoiceOnStatus);
 
-        if (Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED === $klarnaInvoiceStatus) {
+        if (Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED === $authorizablePaymentInvoiceOnStatus) {
             $this->updateAuthorizablePaymentOrderStatus(true);
 
             return;

--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -13,10 +13,10 @@
 namespace Mollie\Service;
 
 use Cart;
-use Configuration;
 use Currency;
 use Db;
 use Mollie;
+use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Order as MollieOrderAlias;
 use Mollie\Api\Resources\Payment;
@@ -79,6 +79,8 @@ class TransactionService
     private $logger;
     /** @var ExceptionService */
     private $exceptionService;
+    /** @var ConfigurationAdapter */
+    private $configurationAdapter;
 
     public function __construct(
         ModuleFactory $moduleFactory,
@@ -90,7 +92,8 @@ class TransactionService
         OrderPaymentFeeHandler $orderPaymentFeeHandler,
         ShipmentSenderHandlerInterface $shipmentSenderHandler,
         PrestaLoggerInterface $logger,
-        ExceptionService $exceptionService
+        ExceptionService $exceptionService,
+        ConfigurationAdapter $configurationAdapter
     ) {
         $this->module = $moduleFactory->getModule();
         $this->orderStatusService = $orderStatusService;
@@ -102,6 +105,7 @@ class TransactionService
         $this->shipmentSenderHandler = $shipmentSenderHandler;
         $this->logger = $logger;
         $this->exceptionService = $exceptionService;
+        $this->configurationAdapter = $configurationAdapter;
     }
 
     /**
@@ -121,7 +125,7 @@ class TransactionService
     public function processTransaction($apiPayment)
     {
         if (empty($apiPayment)) {
-            if (Configuration::get(Config::MOLLIE_DEBUG_LOG) >= Config::DEBUG_LOG_ERRORS) {
+            if ($this->configurationAdapter->get(Config::MOLLIE_DEBUG_LOG) >= Config::DEBUG_LOG_ERRORS) {
                 PrestaShopLogger::addLog(__METHOD__ . ' said: Received webhook request without proper transaction ID.', Config::WARNING);
             }
 
@@ -199,10 +203,10 @@ class TransactionService
                     throw new TransactionException('Cart id is missing in transaction metadata', HttpStatusCode::HTTP_UNPROCESSABLE_ENTITY);
                 }
 
-                $isKlarnaOrder = in_array($apiPayment->method, Config::KLARNA_PAYMENTS, false);
+                $isAuthorizablePayment = in_array($apiPayment->method, Config::AUTHORIZABLE_PAYMENTS, false);
 
                 if (!$orderId && $isPaymentFinished) {
-                    $orderId = $this->orderCreationHandler->createOrder($apiPayment, $cart->id, $isKlarnaOrder);
+                    $orderId = $this->orderCreationHandler->createOrder($apiPayment, $cart->id, $isAuthorizablePayment);
 
                     if (!$orderId) {
                         throw new TransactionException('Order is already created', HttpStatusCode::HTTP_METHOD_NOT_ALLOWED);
@@ -257,9 +261,16 @@ class TransactionService
                         $this->handleOrderDescription($apiPayment);
                     }
                 } else {
-                    $isKlarnaDefault = Configuration::get(Config::MOLLIE_KLARNA_INVOICE_ON) === Config::MOLLIE_STATUS_DEFAULT;
-                    if (in_array($apiPayment->method, Config::KLARNA_PAYMENTS) && !$isKlarnaDefault && $apiPayment->status === OrderStatus::STATUS_COMPLETED) {
-                        $this->orderStatusService->setOrderStatus($orderId, Config::MOLLIE_STATUS_KLARNA_SHIPPED);
+                    $isAuthorizablePaymentInvoiceOnStatusDefault =
+                        $this->configurationAdapter->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS)
+                        === Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT;
+
+                    if (
+                        !$isAuthorizablePaymentInvoiceOnStatusDefault
+                        && $apiPayment->status === OrderStatus::STATUS_COMPLETED
+                        && in_array($apiPayment->method, Config::AUTHORIZABLE_PAYMENTS, true)
+                    ) {
+                        $this->orderStatusService->setOrderStatus($orderId, Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED);
                     } else {
                         $this->orderStatusService->setOrderStatus($orderId, $apiPayment->status);
                     }
@@ -284,7 +295,7 @@ class TransactionService
         $this->savePaymentStatus($apiPayment->id, $apiPayment->status, $orderId);
 
         // Log successful webhook requests in extended log mode only
-        if (Config::DEBUG_LOG_ALL == Configuration::get(Config::MOLLIE_DEBUG_LOG)) {
+        if (Config::DEBUG_LOG_ALL == $this->configurationAdapter->get(Config::MOLLIE_DEBUG_LOG)) {
             PrestaShopLogger::addLog(__METHOD__ . ' said: Received webhook request for order ' . (int) $orderId . ' / transaction ' . $apiPayment->id, Config::NOTICE);
         }
 
@@ -368,7 +379,7 @@ class TransactionService
             throw $e;
         }
 
-        if (!$result && Configuration::get(Config::MOLLIE_DEBUG_LOG) >= Config::DEBUG_LOG_ERRORS) {
+        if (!$result && $this->configurationAdapter->get(Config::MOLLIE_DEBUG_LOG) >= Config::DEBUG_LOG_ERRORS) {
             PrestaShopLogger::addLog(__METHOD__ . ' said: Could not save Mollie payment status for transaction "' . $transactionId . '". Reason: ' . Db::getInstance()->getMsgError(), Config::WARNING);
         }
 
@@ -446,7 +457,7 @@ class TransactionService
 
     private function updateOrderDescription(MollieOrderAlias $apiPayment, int $orderId)
     {
-        $environment = (int) Configuration::get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
+        $environment = (int) $this->configurationAdapter->get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
         $paymentMethodId = $this->paymentMethodRepository->getPaymentMethodIdByMethodId($apiPayment->method, $environment);
         $paymentMethodObj = new MolPaymentMethod((int) $paymentMethodId);
         $orderNumber = TextGeneratorUtility::generateDescriptionFromCart($paymentMethodObj->description, $orderId);
@@ -472,7 +483,7 @@ class TransactionService
         if (!$orderId) {
             throw new TransactionException('Order does not exist', HttpStatusCode::HTTP_METHOD_NOT_ALLOWED);
         }
-        $environment = (int) Configuration::get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
+        $environment = (int) $this->configurationAdapter->get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
         $paymentMethodId = $this->paymentMethodRepository->getPaymentMethodIdByMethodId($apiPayment->method, $environment);
         $paymentMethodObj = new MolPaymentMethod((int) $paymentMethodId);
         $apiPayment->description = TextGeneratorUtility::generateDescriptionFromCart($paymentMethodObj->description, $orderId);

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -188,8 +188,7 @@ final class BaseServiceProvider
         $this->addService($container, PaymentMethodPositionHandlerInterface::class, PaymentMethodPositionHandler::class)
             ->withArgument(PaymentMethodRepositoryInterface::class);
 
-        $this->addService($container, CertificateHandlerInterface::class, ApplePayDirectCertificateHandler::class)
-            ->withArgument(Mollie::class);
+        $this->addService($container, CertificateHandlerInterface::class, $container->get(ApplePayDirectCertificateHandler::class));
 
         $this->addService($container, ProfileIdProviderInterface::class, ProfileIdProvider::class);
 

--- a/src/Validator/OrderConfMailValidator.php
+++ b/src/Validator/OrderConfMailValidator.php
@@ -59,7 +59,7 @@ class OrderConfMailValidator implements MailValidatorInterface
             return true;
         }
 
-        if ((int) $this->configurationAdapter->get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED) === $orderStateId) {
+        if ((int) $this->configurationAdapter->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED) === $orderStateId) {
             return true;
         }
 

--- a/tests/Integration/Install/OrderStateInstallerTest.php
+++ b/tests/Integration/Install/OrderStateInstallerTest.php
@@ -86,7 +86,7 @@ class OrderStateInstallerTest extends BaseTestCase
                 'pdfInvoice' => false,
             ],
             [
-                'key' => Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+                'key' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
                 'color' => '#8A2BE2',
                 'sendEmail' => true,
                 'logable' => true,
@@ -97,7 +97,7 @@ class OrderStateInstallerTest extends BaseTestCase
                 'pdfInvoice' => true,
             ],
             [
-                'key' => Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+                'key' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
                 'color' => '#8A2BE2',
                 'sendEmail' => true,
                 'logable' => true,

--- a/upgrade/Upgrade-4.2.0.php
+++ b/upgrade/Upgrade-4.2.0.php
@@ -11,6 +11,7 @@
 
 use Mollie\Config\Config;
 use Mollie\Install\Installer;
+use Mollie\Install\OrderStateInstaller;
 use Mollie\Service\OrderStateImageService;
 
 if (!defined('_PS_VERSION_')) {
@@ -30,14 +31,13 @@ function upgrade_module_4_2_0($module)
     $segment->setMessage('Mollie upgrade 4.2.0');
     $segment->track();
 
-    /** @var Installer $installer */
-    $installer = $module->getService(Installer::class);
+    /** @var OrderStateInstaller $orderStateInstaller */
+    $orderStateInstaller = $module->getService(OrderStateInstaller::class);
 
-    $installer->klarnaPaymentAuthorizedState();
-    $installer->klarnaPaymentShippedState();
+    $orderStateInstaller->install();
 
-    $acceptedStatusId = Configuration::get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED);
-    Configuration::updateValue(Config::MOLLIE_KLARNA_INVOICE_ON, $acceptedStatusId);
+    $acceptedStatusId = Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED);
+    Configuration::updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS, $acceptedStatusId);
 
     $module->registerHook('actionOrderGridQueryBuilderModifier');
     $module->registerHook('actionOrderGridDefinitionModifier');

--- a/views/templates/admin/invoice_description.tpl
+++ b/views/templates/admin/invoice_description.tpl
@@ -7,10 +7,10 @@
 * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
 *}
 <p>
-    {l s='Select when to send Klarna invoices' mod='mollie'}
+    {l s='Select when to create the Order invoice' mod='mollie'}
 </p>
 <p class="help-block">
-    {l s='Default: The invoice is created based on Order settings > Statuses. There is no custom status created for Klarna.' mod='mollie'}
+    {l s='Default: The invoice is created based on Order settings > Statuses. There is no custom status created.' mod='mollie'}
 </p>
 <p class="help-block">
     {l s='Authorised: Create a full invoice when the order is authorized. Custom status is created.' mod='mollie'}


### PR DESCRIPTION
Setup configuration for Billie method. Additionally improved some service constructors to use adapter for module to avoid forever looping in module construct.

Based on https://github.com/mollie/PrestaShop/pull/788 PR 